### PR TITLE
Correct from h,w to w,h in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -97,8 +97,8 @@ class OmnidataModel:
 
         if h_net != h_raw or w_net != w_raw:
             resizer = Resize(
-                h_net,
                 w_net,
+                h_net,
                 resize_target=None,
                 keep_aspect_ratio=True,
                 ensure_multiple_of=self.patch_size,


### PR DESCRIPTION
Hi, I notice a minor mistake in run.py, where the order of h, w arguments is reversed. In this PR, I have made it consistent with the Resize interface